### PR TITLE
Support 1.8.7 outside of Rails context

### DIFF
--- a/lib/rspec-console/config_cache.rb
+++ b/lib/rspec-console/config_cache.rb
@@ -69,3 +69,14 @@ class Proxy < Struct.new(:output, :target)
     self.target.send(method, *args, &block)
   end
 end
+
+# For compatibility with Ruby 1.8.x outside of the Rails framework
+if RUBY_VERSION =~ /1.8/
+  unless defined?(Rails)
+    class Object
+      def singleton_class
+        class << self; self; end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I just remembered that `#singleton_class` was added by the Rails framework for older Rubies, so if someone wants to use `rspec-console` outside of a Rails app, we should define it for them, since it is required for the metaprogramming of `#method_missing` in `RSpec::ConfigCache`. Thanks again!
