### PR TITLE
Support RSpec3

### DIFF
--- a/lib/rspec-console/runner.rb
+++ b/lib/rspec-console/runner.rb
@@ -9,22 +9,32 @@ class RSpecConsole::Runner
 
       ::RSpec::Core::Runner.disable_autorun!
       ::RSpec::Core::Configuration.class_eval { define_method(:command) { 'rspec' } }
-      ::RSpec.reset
 
-      config_cache.cache do
-        ::RSpec.configure do |config|
-          config.output_stream = STDOUT
-          config.color         = true
+      if ::RSpec::Core::Version::STRING >= "3.0.0"
+        ::RSpec.world.reset
+        ::RSpec.configuration.reset
+      else
+        ::RSpec.reset
+
+        config_cache.cache do
+          ::RSpec.configure do |config|
+            config.output_stream = STDOUT
+            config.color         = true
+          end
+
+          require "./spec/spec_helper"
         end
-
-        require "./spec/spec_helper"
       end
     end
 
     def run(args)
       RSpecConsole.hooks.each(&:call)
       reset(args)
-      ::RSpec::Core::CommandLine.new(args).run(STDERR, STDOUT)
+      if ::RSpec::Core::Version::STRING >= "3.0.0"
+        ::RSpec::Core::Runner.run(args)
+      else
+        ::RSpec::Core::CommandLine.new(args).run(STDERR, STDOUT)
+      end
     end
 
     def config_cache


### PR DESCRIPTION
My workaround for rspec 3.

Use `RSpec::Core::Runner` instead of `RSpec::Core::CommandLine`:

 [Merge RSpec::Core::CommandLine (never formally declared public) into RSpec::Core::Runner. (Myron Marston)](https://github.com/rspec/rspec-core/blob/master/Changelog.md#300rc1--2014-05-18)

Use `RSpec::Core::World#reset` and `RSpec::Core::Configuration#reset` which currently private api:
- [rspec-core/lib/rspec/core/world.rb at v3.0.3 · rspec/rspec-core](https://github.com/rspec/rspec-core/blob/v3.0.3/lib/rspec/core/world.rb#L48,L54)
- [rspec-core/lib/rspec/core/configuration.rb at v3.0.3 · rspec/rspec-core](https://github.com/rspec/rspec-core/blob/v3.0.3/lib/rspec/core/configuration.rb#L315,L320)

Use `config.color` instead of `config.color_enabled`:

[Remove color_enabled as an alias of color. (Jon Rowe)](https://github.com/rspec/rspec-core/blob/v3.0.3/Changelog.md#300rc1--2014-05-18)
