### PR TITLE
Reset config to pick up command line arguments

### DIFF
--- a/lib/rspec-console/runner.rb
+++ b/lib/rspec-console/runner.rb
@@ -31,6 +31,7 @@ class RSpecConsole::Runner
       RSpecConsole.hooks.each(&:call)
       reset(args)
       if defined?(::RSpec::Core::CommandLine)
+        ::RSpec.configuration.reset
         ::RSpec::Core::CommandLine.new(args).run(STDERR, STDOUT)
       else
         ::RSpec::Core::Runner.run(args, STDERR, STDOUT)


### PR DESCRIPTION
I often switch between using just `rspec` and `rspec -fd`.  This makes that possible.