### PR TITLE
Silence logger option

### DIFF
--- a/lib/rspec-console/pry.rb
+++ b/lib/rspec-console/pry.rb
@@ -1,17 +1,34 @@
 module RSpecConsole::Pry
   def self.setup
-    ::Pry::CommandSet.new do
+    ::Pry::CommandSet.new(&rspec_command).tap { |cmd| ::Pry::Commands.import cmd }
+  end
+
+  def self.rspec_command
+    Proc.new do
       create_command "rspec", "Works pretty much like the regular rspec command" do
         group "Testing"
 
         def process(*args)
+          if defined?(ActiveRecord) && ENV['SILENCE_AR'] == true
+            # Silence active record logger while running rspec from console
+            old_logger = ActiveRecord::Base.logger
+            ActiveRecord::Base.logger = Logger.new("#{Rails.root}/log/test.log")
+          end
+
           RSpecConsole::Runner.run(args)
+
+          if defined?(ActiveRecord) && ENV['SILENCE_AR'] == true
+            # Restore default logger
+            ActiveRecord::Base.logger = old_logger
+          end
         end
 
         def complete(input)
           super + Bond::Rc.files(input.split(" ").last || '')
         end
       end
-    end.tap { |cmd| ::Pry::Commands.import cmd }
+    end
   end
+
+  private_class_method :rspec_command
 end

--- a/lib/rspec-console/pry.rb
+++ b/lib/rspec-console/pry.rb
@@ -10,7 +10,7 @@ module RSpecConsole::Pry
         group "Testing"
 
         def process(*args)
-          if defined?(ActiveRecord) && ENV['SILENCE_AR'] == true
+          if defined?(ActiveRecord) == 'constant' && ENV['SILENCE_AR'] == 'true'
             # Silence active record logger while running rspec from console
             old_logger = ActiveRecord::Base.logger
             ActiveRecord::Base.logger = Logger.new("#{Rails.root}/log/test.log")
@@ -18,7 +18,7 @@ module RSpecConsole::Pry
 
           RSpecConsole::Runner.run(args)
 
-          if defined?(ActiveRecord) && ENV['SILENCE_AR'] == true
+          if defined?(ActiveRecord) == 'constant' && ENV['SILENCE_AR'] == 'true'
             # Restore default logger
             ActiveRecord::Base.logger = old_logger
           end

--- a/lib/rspec-console/pry.rb
+++ b/lib/rspec-console/pry.rb
@@ -1,11 +1,12 @@
 module RSpecConsole::Pry
   def self.setup
-    ::Pry::CommandSet.new(&rspec_command).tap { |cmd| ::Pry::Commands.import cmd }
+    ::Pry::CommandSet.new(&rspec_command).
+      tap { |cmd| ::Pry::Commands.import cmd }
   end
 
   def self.rspec_command
     Proc.new do
-      create_command "rspec", "Works pretty much like the regular rspec command" do
+      create_command "rspec", "Runs specs; to silence ActiveRecord output use SILENCE_AR=true" do
         group "Testing"
 
         def process(*args)

--- a/spec/rspec-console/config_cache_spec.rb
+++ b/spec/rspec-console/config_cache_spec.rb
@@ -8,7 +8,7 @@ describe RSpecConsole::ConfigCache do
   describe "#cache" do
     it "defines method_missing method on RSpec.configuration's singleton class" do
       cache.cache {}
-      RSpec.configuration.respond_to?(:method_missing).should == true
+      expect(RSpec.configuration.respond_to?(:method_missing)).to be_true
     end
   end
 end

--- a/spec/rspec-console/pry_spec.rb
+++ b/spec/rspec-console/pry_spec.rb
@@ -23,7 +23,7 @@ describe RSpecConsole::Pry do
         to receive(:create_command).
       with(
         "rspec",
-        "Works pretty much like the regular rspec command"
+        "Runs specs; to silence ActiveRecord output use SILENCE_AR=true"
       )
       ::Pry::CommandSet.new(&proc)
     end

--- a/spec/rspec-console/pry_spec.rb
+++ b/spec/rspec-console/pry_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+require "pry"
+
+describe RSpecConsole::Pry do
+  describe ".setup" do
+    it "relies on Pry::Commands" do
+      expect(::Pry::CommandSet).to receive(:new)
+      expect(::Pry::Commands).to receive(:import)
+      RSpecConsole::Pry.setup
+    end
+    it "adds pry command" do
+      RSpecConsole::Pry.setup
+      expect(Pry::Commands.valid_command?("rspec")).to eq(true)
+    end
+  end
+  describe ".rspec_command" do
+    let(:proc) { RSpecConsole::Pry.send(:rspec_command) }
+    it "is a proc" do
+      expect(proc).to be_a(Proc)
+    end
+    it "relies on create_command in Pry" do
+      expect_any_instance_of(::Pry::CommandSet).
+        to receive(:create_command).
+      with(
+        "rspec",
+        "Works pretty much like the regular rspec command"
+      )
+      ::Pry::CommandSet.new(&proc)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,4 @@ $LOAD_PATH.unshift File.expand_path("../../", __FILE__)
 require "rspec-console"
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
-  config.run_all_when_everything_filtered = true
-  config.filter_run :focus
 end


### PR DESCRIPTION
While using `rspec-console` in Rails, the ActiveRecord logging to console output can obscure the test output. (If you have a noisy database.) My code changes allow a user to set an environment variable to silence the log while running tests in `rails c test`. I'd like to put more tests around the Pry command itself, but I can confirm this command works in my apps (mix of jruby, Ruby 2, Rails 3 and 4).

All other changes are "boyscout rule" changes in response to deprecation warnings.